### PR TITLE
Resource type determination functions working incorrectly.

### DIFF
--- a/projects/ngx-hateoas-client/src/lib/model/resource-type.ts
+++ b/projects/ngx-hateoas-client/src/lib/model/resource-type.ts
@@ -10,11 +10,19 @@ export function isResource(object: any): boolean {
 }
 
 export function isResourceCollection(object: any): boolean {
-  return isObject(object) && ('_embedded' in object) && !('page' in object);
+  return isObject(object) &&
+         ('_embedded' in object) &&
+         ('_links' in object) &&
+         !('page' in object) &&
+         (Object.keys(object).length === 2);
 }
 
 export function isPagedResourceCollection(object: any): boolean {
-  return isObject(object) && ('_embedded' in object) && ('page' in object);
+  return isObject(object) &&
+         ('_embedded' in object) &&
+         ('_links' in object) &&
+         ('page' in object) &&
+         (Object.keys(object).length === 3);
 }
 
 /**

--- a/projects/ngx-hateoas-client/src/lib/model/resource/resources.test.ts
+++ b/projects/ngx-hateoas-client/src/lib/model/resource/resources.test.ts
@@ -22,6 +22,13 @@ export class RawEmbeddedResource extends EmbeddedResource {
 
 export const rawResource = {
   name: 'Test',
+  _embedded: {
+    resources: [
+      {
+        name: 'test'
+      }
+    ]
+  },
   _links: {
     self: {
       href: 'http://localhost:8080/api/v1/resource/1'


### PR DESCRIPTION
The function `isResource(...)` is working incorrectly. An entity `A` in Spring Data REST can embed another entity `B` if, for example, if both `A` and `B` have a `@ManyToMany` relation with each other (one with `mappedBy=...`). If in this case `A` is queried, it returns `A` with its usual properties, the `_links` key and an `_embedded` key containing entities `B`.

This pull request fixes this by adding a check for the number of properties the main object contains.

I'd be happy if you could approve this pull request and provide a fixed version in npm. Thanks!