### PR TITLE
Add hasRelation() function to abstract-resource.ts

### DIFF
--- a/projects/ngx-hateoas-client/src/lib/model/resource/abstract-resource.spec.ts
+++ b/projects/ngx-hateoas-client/src/lib/model/resource/abstract-resource.spec.ts
@@ -108,7 +108,7 @@ describe('AbstractResource', () => {
     expect(linkAbstractResource.hasRelation('self')).toBeTrue();
   });
 
-  it('should return false if relation links are empty', function () {
+  it('should return false if relation links are empty', () => {
     expect(emptyLinkAbstractResource.hasRelation('self')).toBeFalse();
     expect(emptyLinkAbstractResource.hasRelation('products')).toBeFalse();
   });

--- a/projects/ngx-hateoas-client/src/lib/model/resource/abstract-resource.spec.ts
+++ b/projects/ngx-hateoas-client/src/lib/model/resource/abstract-resource.spec.ts
@@ -19,11 +19,27 @@ class TestAbstractResource extends AbstractResource {
   };
 }
 
+class TestLinkAbstractResource extends AbstractResource {
+  _links = {
+    self: {
+      href: "http://localhost:8080/api/v1/linkResource/1"
+    }
+  }
+}
+
+class TestEmptyLinkAbstractResource extends AbstractResource{
+  _links = {}
+}
+
 describe('AbstractResource', () => {
   let abstractResource: AbstractResource;
+  let linkAbstractResource: AbstractResource;
+  let emptyLinkAbstractResource: AbstractResource;
 
   beforeEach(() => {
     abstractResource = new TestAbstractResource();
+    linkAbstractResource = new TestLinkAbstractResource();
+    emptyLinkAbstractResource = new TestEmptyLinkAbstractResource();
   });
 
   it('should throw error when _links object is empty', () => {
@@ -82,6 +98,19 @@ describe('AbstractResource', () => {
 
     expect(relationLink).toBeDefined();
     expect(relationLink.href).toBe('http://localhost:8080/api/v1/product/1');
+  });
+
+  it('should return false if relation link is not present', () => {
+    expect(linkAbstractResource.hasRelation('products')).toBeFalse();
+  });
+
+  it('should return true if relation link is present',  () => {
+    expect(linkAbstractResource.hasRelation('self')).toBeTrue();
+  });
+
+  it('should return false if relation links are empty', function () {
+    expect(emptyLinkAbstractResource.hasRelation('self')).toBeFalse();
+    expect(emptyLinkAbstractResource.hasRelation('products')).toBeFalse();
   });
 
 });

--- a/projects/ngx-hateoas-client/src/lib/model/resource/abstract-resource.ts
+++ b/projects/ngx-hateoas-client/src/lib/model/resource/abstract-resource.ts
@@ -31,4 +31,18 @@ export abstract class AbstractResource {
     return relationLink;
   }
 
+  /**
+   * Checks if relation link is present.
+   *
+   * @param relationName used to check for the specified relation name
+   * @returns true if link is present, false otherwise
+   */
+  public hasRelation(relationName: string): boolean {
+    if (isEmpty(this._links)) {
+      return false;
+    } else {
+      return Object.keys(this._links).indexOf(relationName) !== -1;
+    }
+  }
+
 }

--- a/projects/ngx-hateoas-client/src/lib/model/resource/abstract-resource.ts
+++ b/projects/ngx-hateoas-client/src/lib/model/resource/abstract-resource.ts
@@ -41,7 +41,7 @@ export abstract class AbstractResource {
     if (isEmpty(this._links)) {
       return false;
     } else {
-      return Object.keys(this._links).indexOf(relationName) !== -1;
+      return !isEmpty(this._links[relationName]);
     }
   }
 


### PR DESCRIPTION
While developing an application I encountered the absence of a function to check if a specific relation is present in the `_links` object.
The sole information if a relation is present may be useful to, for example, disable/hide a button/column or else.

Please consider merging this pull request. If you have any questions, please ask away!

Best Regards, Daniel.